### PR TITLE
Add a Dav1d nightly run to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: xenial
 language: rust
 
 rust:
-  #- stable ## Let's spare Travis
+ - stable
  - nightly
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,12 @@ dist: xenial
 language: rust
 
 rust:
- - stable
+ #- stable
  - nightly
  
 env:
  - DAV1D: "Stable"
- #- DAV1D: "Nightly"
+ - DAV1D: "Nightly"
 
 addons:
   apt:
@@ -30,6 +30,10 @@ before_install:
         wget https://code.videolan.org/videolan/dav1d/-/archive/0.1.0/dav1d-0.1.0.tar.gz;
         tar -xvf dav1d-0.1.0.tar.gz;
         cd dav1d-0.1.0;
+      fi
+    - if [ $DAV1D == "Nightly" ]; then
+        git clone https://code.videolan.org/videolan/dav1d.git;
+        cd dav1d;
       fi
     - meson .build
     - ninja -C .build

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,17 @@ language: rust
 rust:
  - stable
  - nightly
+ 
+env:
+ - DAV1D: "Stable"
+ #- DAV1D: "Nightly"
 
 addons:
   apt:
     update: true
 
 before_install:
+    # Install Meson, Ninja & Nasm
     - sudo apt-get install -y ninja-build python3-pip python3-setuptools
     - pip3 install meson
     - wget https://www.nasm.us/pub/nasm/releasebuilds/2.14.02/nasm-2.14.02.tar.xz
@@ -19,9 +24,13 @@ before_install:
     - make
     - sudo make install
     - nasm --version
-    - wget https://code.videolan.org/videolan/dav1d/-/archive/0.1.0/dav1d-0.1.0.tar.gz
-    - tar -xvf dav1d-0.1.0.tar.gz
-    - cd dav1d-0.1.0
+    
+    # Install dav1d
+    - if [ $DAV1D == "Stable" ] then
+      - wget https://code.videolan.org/videolan/dav1d/-/archive/0.1.0/dav1d-0.1.0.tar.gz
+      - tar -xvf dav1d-0.1.0.tar.gz
+      - cd dav1d-0.1.0
+    - fi
     - meson .build
     - ninja -C .build
     - sudo ninja -C .build install
@@ -30,4 +39,3 @@ before_install:
 script:
  - cargo build --release --verbose
  - cargo test --verbose
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,10 @@ before_install:
     - nasm --version
     
     # Install dav1d
-    - if [ $DAV1D == "Stable" ] then \
-        wget https://code.videolan.org/videolan/dav1d/-/archive/0.1.0/dav1d-0.1.0.tar.gz & \
-        tar -xvf dav1d-0.1.0.tar.gz & \
-        cd dav1d-0.1.0 & \
+    - if [ $DAV1D == "Stable" ] then
+        wget https://code.videolan.org/videolan/dav1d/-/archive/0.1.0/dav1d-0.1.0.tar.gz &&
+        tar -xvf dav1d-0.1.0.tar.gz &&
+        cd dav1d-0.1.0
       fi
     - meson .build
     - ninja -C .build

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,10 @@ before_install:
     - nasm --version
     
     # Install dav1d
-    - if [ $DAV1D == "Stable" ] then
-        wget https://code.videolan.org/videolan/dav1d/-/archive/0.1.0/dav1d-0.1.0.tar.gz &&
-        tar -xvf dav1d-0.1.0.tar.gz &&
-        cd dav1d-0.1.0
+    - if [ $DAV1D == "Stable" ]; then
+        wget https://code.videolan.org/videolan/dav1d/-/archive/0.1.0/dav1d-0.1.0.tar.gz;
+        tar -xvf dav1d-0.1.0.tar.gz;
+        cd dav1d-0.1.0;
       fi
     - meson .build
     - ninja -C .build

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,12 @@ dist: xenial
 language: rust
 
 rust:
- #- stable
+ - stable
  - nightly
  
 env:
- - DAV1D: "Stable"
- - DAV1D: "Nightly"
+ - Dav1d: "stable"
+ - Dav1d: "nightly"
 
 addons:
   apt:
@@ -26,12 +26,12 @@ before_install:
     - nasm --version
     
     # Install dav1d
-    - if [ $DAV1D == "Stable" ]; then
+    - if [ $Dav1d == "stable" ]; then
         wget https://code.videolan.org/videolan/dav1d/-/archive/0.1.0/dav1d-0.1.0.tar.gz;
         tar -xvf dav1d-0.1.0.tar.gz;
         cd dav1d-0.1.0;
       fi
-    - if [ $DAV1D == "Nightly" ]; then
+    - if [ $Dav1d == "nightly" ]; then
         git clone https://code.videolan.org/videolan/dav1d.git;
         cd dav1d;
       fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,11 @@ before_install:
     - nasm --version
     
     # Install dav1d
-    - if [ $DAV1D == "Stable" ] then
-      - wget https://code.videolan.org/videolan/dav1d/-/archive/0.1.0/dav1d-0.1.0.tar.gz
-      - tar -xvf dav1d-0.1.0.tar.gz
-      - cd dav1d-0.1.0
-    - fi
+    - if [ $DAV1D == "Stable" ] then \
+        wget https://code.videolan.org/videolan/dav1d/-/archive/0.1.0/dav1d-0.1.0.tar.gz & \
+        tar -xvf dav1d-0.1.0.tar.gz & \
+        cd dav1d-0.1.0 & \
+      fi
     - meson .build
     - ninja -C .build
     - sudo ninja -C .build install

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# libdav1d bindings
-
-[![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+# libdav1d bindings [![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)  [![Travis Build Status](https://travis-ci.org/rust-av/dav1d-rs.svg?branch=master)](https://travis-ci.org/rust-av/dav1d-rs)
 
 It is a simple [binding][1] and safe abstraction over [dav1d][2].
 


### PR DESCRIPTION
This replaces #4.

- Adds Travis build status badge to Readme
- Enables builds with Rust stable
- Enables builds with dav1d nightly (clone from git master)