### PR TITLE
Bump bindgen to 0.48

### DIFF
--- a/dav1d-sys/Cargo.toml
+++ b/dav1d-sys/Cargo.toml
@@ -12,7 +12,7 @@ build = "build.rs"
 dav1d = "0.1.0"
 
 [build-dependencies]
-bindgen = "0.47"
+bindgen = "0.48"
 metadeps = "1.1.2"
 pkg-config = "0.3.12"
 


### PR DESCRIPTION
Signed-off-by: Robert-André Mauchin <zebob.m@gmail.com>


Tested in Fedora Rawhide.
https://copr.fedorainfracloud.org/coprs/eclipseo/rav1e/package/rust-dav1d-sys/