### PR TITLE
Add build feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,5 @@ dav1d-sys = { version = "0.2.0", path = "dav1d-sys" }
 [workspace]
 members = ["dav1d-sys", "tools"]
 
+[features]
+build = ["dav1d-sys/build"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@ It is a simple [binding][1] and safe abstraction over [dav1d][2].
 
 ## Building
 
-By default the bindings are generated using the headers and libraries that ought to be present in the system.
+By default the bindings are generated using the headers and libraries that ought to be present in the system. However a cargo feature also allows to optionally build and statically link libdav1d into the -sys bindings:
+
+```shell
+$ cargo build --features=build
+```
 
 ## TODO
 - [x] Simple bindings


### PR DESCRIPTION
Proxy the build feature from the -sys subcrate so that the bindings can embed
libdav1d as a statically linked library.