### PR TITLE
API change for Picture::plane_data()

### DIFF
--- a/dav1d-sys/build.rs
+++ b/dav1d-sys/build.rs
@@ -13,7 +13,7 @@ use std::path::PathBuf;
 mod build {
     use super::*;
     use std::path::Path;
-    use std::process::Command;
+    use std::process::{Command, Stdio};
 
     const REPO: &'static str = "https://code.videolan.org/videolan/dav1d.git";
 
@@ -21,8 +21,11 @@ mod build {
         ($cmd:expr, $($arg:expr),*) => {
             Command::new($cmd)
                 $(.arg($arg))*
+                .stderr(Stdio::inherit())
+                .stdout(Stdio::inherit())
                 .output()
-                .expect(concat!("{} failed", $cmd));
+                .expect(concat!($cmd, " failed"));
+
         };
     }
 


### PR DESCRIPTION
This method now returns a slice and the stride associated with the requested
plane component. This is more convenient when safely copying the decoded
picture.

The plane data pointer is now accessible through the plane_data_ptr() method.