### PR TITLE
Add Picture offset metadata accessor

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -301,6 +301,10 @@ impl Picture {
     pub fn duration(&self) -> i64 {
         (*self.inner).pic.m.duration as i64
     }
+
+    pub fn offset(&self) -> i64 {
+        (*self.inner).pic.m.offset
+    }
 }
 
 unsafe impl Send for Picture {}


### PR DESCRIPTION
As this is a small change, perhaps it could go in a 0.4.1?
I need this for the GStreamer plugin after the latest round of review from @sdroege 