### PR TITLE
sys: actually use metadeps

### DIFF
--- a/dav1d-sys/Cargo.toml
+++ b/dav1d-sys/Cargo.toml
@@ -17,6 +17,5 @@ dav1d = "0.2.0"
 [build-dependencies]
 bindgen = "0.53.1"
 metadeps = "1.1.2"
-pkg-config = "0.3.12"
 
 [dependencies]

--- a/dav1d-sys/build.rs
+++ b/dav1d-sys/build.rs
@@ -1,8 +1,7 @@
 // build.rs
 
 extern crate bindgen;
-#[cfg(unix)]
-extern crate pkg_config;
+extern crate metadeps;
 
 use std::env;
 use std::fs::File;
@@ -74,7 +73,8 @@ fn main() {
         build_from_src();
     }
 
-    let libs = pkg_config::Config::new().probe("dav1d").unwrap();
+    let libs = metadeps::probe().unwrap();
+    let libs = libs.get("dav1d").unwrap();
 
     let headers = libs.include_paths.clone();
 


### PR DESCRIPTION
It was listed as dependency but was not actually used.

Metadeps will ensure that the dav1d version detected by pkg-config matches the
version requirement defined in Cargo.toml.