### PR TITLE
sys: use system-deps build internal feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,3 @@ dav1d-sys = { version = "0.3.2", path = "dav1d-sys" }
 
 [workspace]
 members = ["dav1d-sys", "tools"]
-
-[features]
-build = ["dav1d-sys/build"]

--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ It is a simple [binding][1] and safe abstraction over [dav1d][2].
 
 ## Building
 
-By default the bindings are generated using the headers and libraries that ought to be present in the system. However a cargo feature also allows to optionally build and statically link libdav1d into the -sys bindings:
+By default the bindings are generated using the headers and libraries that ought to be present in the system.
+However you can optionally build and statically link libdav1d into the -sys bindings:
 
 ```shell
-$ cargo build --features=build
+$ SYSTEM_DEPS_DAV1D_BUILD_INTERNAL=always cargo build
 ```
 
 ## TODO

--- a/dav1d-sys/Cargo.toml
+++ b/dav1d-sys/Cargo.toml
@@ -9,14 +9,11 @@ edition = "2018"
 
 build = "build.rs"
 
-[features]
-build = []
-
-[package.metadata.pkg-config]
+[package.metadata.system-deps]
 dav1d = "0.2.0"
 
 [build-dependencies]
 bindgen = "0.54.0"
-metadeps = "1.1.2"
+system-deps = "1.3"
 
 [dependencies]


### PR DESCRIPTION
system-deps is a fork of metadeps providing new features such as support
for lib internal build.

Replace 'build' feature with system-deps standarized build internal
mechanism.

Fix #26

cc @sdroege