### PR TITLE
Don’t reexport dav1d-sys

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-pub use dav1d_sys::*;
+use dav1d_sys::*;
 
 use std::ffi::c_void;
 use std::i64;


### PR DESCRIPTION
This unclutters the documentation, and we couldn’t mix the two APIs
anyway, users should use dav1d-sys directly if they want to use that
API.