### PR TITLE
Export Settings wrapper for native Dav1dSettings

### DIFF
--- a/.github/workflows/dav1d.yml
+++ b/.github/workflows/dav1d.yml
@@ -25,7 +25,7 @@ jobs:
       env:
         DAV1D_DIR: dav1d_dir
       run: |
-        git clone --depth 1 https://code.videolan.org/videolan/dav1d.git
+        git clone --branch 0.9.2 --depth 1 https://code.videolan.org/videolan/dav1d.git
         cd dav1d
         meson build -Dprefix=$HOME/$DAV1D_DIR --buildtype release
         ninja -C build


### PR DESCRIPTION
Hello. We're using gst-plugins-rs's dav1ddec plugin to decode AV1 video. I noticed that dav1d by default does not decode tiles in parallel, but can be requested to do so by setting Dav1dSettings.n_tile_threads to a higher value. This is currently impossible with the simple dav1d-rs API.

This patch sequence exports the Dav1dSettings struct publicly, allowing clients to override default settings and set this and other values as they wish. It also changes the default Dav1dDecoder::new() constructor to initialize this value to the number of CPUs, clamped to [1,4], as VLC does (see below).

It's an RFC because I'm unsure about some things:

- Is it OK to export Dav1dSettings directly (especially after c9402034dcefec1bf8462b9826076b0c9bcde6aa)? We could wrap it. Note it contains some ugly stuff like some function pointers. If it is OK, is there a more rust-y way to do this than the clumsy  `new_default_settings` function I wrote?
- This adds a new depencency on [num_cpus](https://crates.io/crates/num_cpus). Is that a problem?
- Are existing users OK with having their decoding changed to be in parallel? We could instead require downstream projects to set these values, leaving the default behavior unchanged, and avoiding the num_cpus dependency in dav1d-rs. But that requires coordinated changes in those downstream projects, for possibly no real advantage. Cc some known downstream users: @sdroege @HeroicKatora @fintelia

---

VLC's n_tile_threads initialization, from https://code.videolan.org/videolan/vlc/-/blob/3.0.16/modules/codec/dav1d.c#L286 :
```c
    p_sys->s.n_tile_threads = var_InheritInteger(p_this, "dav1d-thread-tiles");
    if (p_sys->s.n_tile_threads == 0)
        p_sys->s.n_tile_threads =
            (i_core_count > 4) ? 4 :
            (i_core_count > 1) ? i_core_count :
            1;
```