### PR TITLE
Document that `get_picture()` should be called only once per submitte…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -320,6 +320,10 @@ impl Decoder {
     ///
     /// If this returns `Err([Error::Again])` then further data has to be sent to the decoder
     /// before further decoded frames become available.
+    ///
+    /// To make most use of frame threading this function should only be called once per submitted
+    /// input frame and not until it returns `Err([Error::Again])`. Calling it in a loop should
+    /// only be done to drain all pending frames at the end.
     pub fn get_picture(&mut self) -> Result<Picture, Error> {
         unsafe {
             let mut pic: Dav1dPicture = mem::zeroed();


### PR DESCRIPTION
…d input frame

Otherwise the decoder can't make best use of frame threading and will also more likely run into a race condition in dav1d that causes a deadlock.

Instead calling it in a loop should only happen at the very end to drain all pending frames.

Update the example accordingly.

Fixes https://github.com/rust-av/dav1d-rs/issues/72