### PR TITLE
Fix struct padding size depending on features

### DIFF
--- a/dav1d-sys/src/lib.rs
+++ b/dav1d-sys/src/lib.rs
@@ -611,11 +611,11 @@ pub struct Dav1dSettings {
     pub strict_std_compliance: c_int,
     pub output_invisible_frames: c_int,
     pub inloop_filters: Dav1dInloopFilterType,
+    #[cfg(not(feature = "v1_1"))]
+    pub reserved: [u8; 20usize],
     #[cfg(feature = "v1_1")]
     pub decode_frame_type: Dav1dDecodeFrameType,
     #[cfg(feature = "v1_1")]
-    pub reserved: [u8; 20usize],
-    #[cfg(not(feature = "v1_1"))]
     pub reserved: [u8; 16usize],
 }
 
@@ -688,6 +688,20 @@ extern "C" {
 mod tests {
     use super::*;
     use std::ffi::CStr;
+
+    macro_rules! assert_size (
+        ($t:ty, $sz:expr) => (
+            assert_eq!(::std::mem::size_of::<$t>(), $sz);
+        );
+    );
+
+    #[test]
+    fn size() {
+        #[cfg(target_pointer_width = "64")]
+        assert_size!(Dav1dSettings, 96);
+        #[cfg(target_pointer_width = "32")]
+        assert_size!(Dav1dSettings, 76);
+    }
 
     #[test]
     fn version() {


### PR DESCRIPTION
fb0355b421609484979ae877d4a1cf2f62db626c introduced the `v1_1` feature, but the size of the `reserved` field in `Dav1dSettings` was mixed up.  It isn’t much of an issue when using this new feature as only four bytes are wasted, but it very much is when not using it, as four bytes of garbage are passed to the functions taking it as a pointer.

I also added a test to avoid reproducing this mistake in the future.