### PR TITLE
Fail if compiling against dav1d newer than 1.2.1

### DIFF
--- a/.github/workflows/dav1d.yml
+++ b/.github/workflows/dav1d.yml
@@ -35,7 +35,7 @@ jobs:
         DAV1D_DIR: dav1d_dir
         LIB_PATH: lib/x86_64-linux-gnu
       run: |
-        git clone --branch 1.1.0 --depth 1 https://code.videolan.org/videolan/dav1d.git
+        git clone --branch 1.2.1 --depth 1 https://code.videolan.org/videolan/dav1d.git
         cd dav1d
         meson build -Dprefix=$HOME/$DAV1D_DIR -Denable_tools=false -Denable_examples=false --buildtype release
         ninja -C build
@@ -91,7 +91,7 @@ jobs:
 
     - name: Build dav1d
       run: |
-        git clone --branch 1.1.0 --depth 1 https://code.videolan.org/videolan/dav1d.git
+        git clone --branch 1.2.1 --depth 1 https://code.videolan.org/videolan/dav1d.git
         cd dav1d
         meson build -Dprefix=C:\build -Denable_tools=false -Denable_examples=false --buildtype release
         ninja -C build

--- a/dav1d-sys/Cargo.toml
+++ b/dav1d-sys/Cargo.toml
@@ -11,6 +11,7 @@ build = "build.rs"
 
 [build-dependencies]
 system-deps = "6.0"
+pkg-config = "0.3"
 
 [dependencies]
 libc = "0.2"

--- a/dav1d-sys/build.rs
+++ b/dav1d-sys/build.rs
@@ -76,4 +76,9 @@ fn main() {
         .add_build_internal("dav1d", build::build_from_src)
         .probe()
         .unwrap();
+
+    pkg_config::Config::new()
+        .range_version("1.0.0"..="1.2.1")
+        .probe("dav1d")
+        .unwrap();
 }

--- a/dav1d-sys/build.rs
+++ b/dav1d-sys/build.rs
@@ -7,7 +7,7 @@ mod build {
     use std::process::{Command, Stdio};
 
     const REPO: &str = "https://code.videolan.org/videolan/dav1d.git";
-    const TAG: &str = "1.1.0";
+    const TAG: &str = "1.2.1";
 
     macro_rules! runner {
         ($cmd:expr, $($arg:expr),*) => {


### PR DESCRIPTION
Newer versions broke API and ABI, and using such a version causes memory
corruption.

----

@lu-zero Can you make a release with this? I'll also make a PR with breaking changes for 1.3.0.