### PR TITLE
Use system-deps to check for dav1d < 1.3

### DIFF
--- a/dav1d-sys/Cargo.toml
+++ b/dav1d-sys/Cargo.toml
@@ -10,8 +10,7 @@ edition = "2021"
 build = "build.rs"
 
 [build-dependencies]
-system-deps = "6.0"
-pkg-config = "0.3"
+system-deps = "6.2"
 
 [dependencies]
 libc = "0.2"
@@ -21,7 +20,7 @@ v1_1 = []
 
 [package.metadata.system-deps.dav1d]
 name = "dav1d"
-version = "1.0.0"
+version = ">= 1.0.0, < 1.3"
 
 [package.metadata.system-deps.dav1d.v1_1]
-version = "1.1.0"
+version = ">= 1.1.0, < 1.3"

--- a/dav1d-sys/build.rs
+++ b/dav1d-sys/build.rs
@@ -23,7 +23,7 @@ mod build {
 
     pub fn build_from_src(
         lib: &str,
-        version: &str,
+        _version: &str,
     ) -> Result<system_deps::Library, system_deps::BuildInternalClosureError> {
         let build_dir = "build";
         let release_dir = "release";
@@ -67,7 +67,7 @@ mod build {
         runner!("meson", "install", "-C", build_path.to_str().unwrap());
 
         let pkg_dir = build_path.join("meson-private");
-        system_deps::Library::from_internal_pkg_config(&pkg_dir, lib, version)
+        system_deps::Library::from_internal_pkg_config(&pkg_dir, lib, TAG)
     }
 }
 
@@ -75,10 +75,5 @@ fn main() {
     system_deps::Config::new()
         .add_build_internal("dav1d", build::build_from_src)
         .probe()
-        .unwrap();
-
-    pkg_config::Config::new()
-        .range_version("1.0.0"..="1.2.1")
-        .probe("dav1d")
         .unwrap();
 }


### PR DESCRIPTION
Otherwise if we check for it ourselves the internal build of dav1d will not be usable.

Fixes https://github.com/rust-av/dav1d-rs/issues/85