### PR TITLE
handle docs.rs in build.rs

### DIFF
--- a/dav1d-sys/build.rs
+++ b/dav1d-sys/build.rs
@@ -72,6 +72,10 @@ mod build {
 }
 
 fn main() {
+    if std::env::var("DOCS_RS").is_ok() {
+        return;
+    }
+
     system_deps::Config::new()
         .add_build_internal("dav1d", build::build_from_src)
         .probe()


### PR DESCRIPTION
This PR fixes #45 

Handle `docs.rs` environment in `dav1d-sys` custom build script, like suggested [in the docs.rs docs](https://docs.rs/about/builds#detecting-docsrs).

As far as I can tell, the build script does not add any functionality visible in the docs, so it should be possible to simply skip it in docs.rs build environments.