### PR TITLE
Mark `InnerPicture` as `Send+Sync`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ version = "0.10.2"
 bitflags = "2"
 dav1d-sys = { version = "0.8.2", path = "dav1d-sys" }
 av-data = "0.4.2"
+static_assertions = "1"
 
 [features]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -413,8 +413,6 @@ impl Decoder {
             } else {
                 let inner = InnerPicture { pic };
                 Ok(Picture {
-                    // https://github.com/rust-av/dav1d-rs/issues/95
-                    #[allow(clippy::arc_with_non_send_sync)]
                     inner: Arc::new(inner),
                 })
             }
@@ -733,6 +731,9 @@ impl Picture {
 
 unsafe impl Send for Picture {}
 unsafe impl Sync for Picture {}
+
+unsafe impl Send for InnerPicture {}
+unsafe impl Sync for InnerPicture {}
 
 impl Drop for InnerPicture {
     fn drop(&mut self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -522,8 +522,7 @@ impl std::ops::Deref for Plane {
     }
 }
 
-unsafe impl Send for Plane {}
-unsafe impl Sync for Plane {}
+static_assertions::assert_impl_all!(Plane: Send, Sync);
 
 /// Number of bits per component.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -729,8 +728,7 @@ impl Picture {
     }
 }
 
-unsafe impl Send for Picture {}
-unsafe impl Sync for Picture {}
+static_assertions::assert_impl_all!(Picture: Send, Sync);
 
 unsafe impl Send for InnerPicture {}
 unsafe impl Sync for InnerPicture {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,6 +78,9 @@ pub struct Settings {
     dav1d_settings: Dav1dSettings,
 }
 
+unsafe impl Send for Settings {}
+unsafe impl Sync for Settings {}
+
 impl Default for Settings {
     fn default() -> Self {
         Self::new()


### PR DESCRIPTION
`Picture` already was and it's just a ref-counting wrapper around it.

Fixes https://github.com/rust-av/dav1d-rs/issues/95