### PR TITLE
Don't pass NULL to `slice::from_raw_parts()`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -885,7 +885,7 @@ impl<A: PictureAllocator> AsRef<[u8]> for Plane<A> {
         if stride == 0 || data.is_null() {
             return &[];
         }
-        unsafe { std::slice::from_raw_parts(data, (stride * height) as usize)) }
+        unsafe { std::slice::from_raw_parts(data, stride as usize * height as usize) }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -881,12 +881,11 @@ impl<A: PictureAllocator> Clone for Plane<A> {
 impl<A: PictureAllocator> AsRef<[u8]> for Plane<A> {
     fn as_ref(&self) -> &[u8] {
         let (stride, height) = self.0.plane_data_geometry(self.1);
-        unsafe {
-            std::slice::from_raw_parts(
-                self.0.plane_data_ptr(self.1) as *const u8,
-                (stride * height) as usize,
-            )
+        let data = self.0.plane_data_ptr(self.1) as *const u8;
+        if stride == 0 || data.is_null() {
+            return &[];
         }
+        unsafe { std::slice::from_raw_parts(data, (stride * height) as usize)) }
     }
 }
 


### PR DESCRIPTION
It's undefined behaviour and causes a debug assertion.
    
Fixes https://github.com/rust-av/dav1d-rs/issues/120

----

And also another fix while we're at it.

@lu-zero can we get a release with this?